### PR TITLE
Update command-line-args dep version to work with node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/PolymerLabs/web-component-shards",
   "dependencies": {
-    "command-line-args": "^1.0.0",
+    "command-line-args": "v4.0.2",
     "es6-promise": "^2.1.0",
     "hydrolysis": "^1.19.1",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/PolymerLabs/web-component-shards",
   "dependencies": {
-    "command-line-args": "v4.0.2",
+    "command-line-args": "^2.0.0",
     "es6-promise": "^2.1.0",
     "hydrolysis": "^1.19.1",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Does not appear to break under our current node v5.10.1, so that's nice.